### PR TITLE
Add test cases to cover low-hanging fruit

### DIFF
--- a/busbus/entity.py
+++ b/busbus/entity.py
@@ -38,7 +38,7 @@ class BaseEntity(object):
             setattr(self, name, value)
             return value
         else:
-            raise AttributeError()
+            raise AttributeError(name)
 
     def to_dict(self):
         return dict((attr, getattr(self, attr)) for attr in self.__attrs__

--- a/busbus/provider/__init__.py
+++ b/busbus/provider/__init__.py
@@ -28,22 +28,24 @@ class ProviderBase(object):
         self._cached_requests = CacheControl(self._requests, cache=FileCache(
             self.engine.config['url_cache_dir']))
 
-    @abstractmethod
     def _new_entity(self, entity):
-        return NotImplemented
+        """
+        Method to receive knowledge of a new entity -- does nothing if not
+        overridden
+        """
 
     @abstractmethod
     def get(self, entity, id, default=None):
-        return NotImplemented
+        """Return the requested entity, or default if it doesn't exist"""
 
     @abstractproperty
     def agencies(self):
-        return NotImplemented
+        """Return an iterator of the agencies for this provider"""
 
     @abstractproperty
     def stops(self):
-        return NotImplemented
+        """Return an iterator of the stops for this provider"""
 
     @abstractproperty
     def routes(self):
-        return NotImplemented
+        """Return an iterator of the routes for this provider"""

--- a/busbus/util/__init__.py
+++ b/busbus/util/__init__.py
@@ -14,7 +14,7 @@ class Iterable(object):
 
     @abstractmethod
     def __next__(self):
-        return NotImplemented
+        """Provide the next item from the iterator in this method."""
 
     # Python 2 compatibility
     def next(self):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,24 @@
+import busbus
+
+import os
+import pytest
+import tempfile
+
+
+def test_engine_busbus_dir_exists():
+    dir = tempfile.mkdtemp()
+    engine = busbus.Engine({'busbus_dir': dir})
+    os.rmdir(dir)
+
+
+def test_engine_busbus_dir_other_error():
+    outerdir = tempfile.mkdtemp()
+    dir = os.path.join(outerdir, 'inner')
+    os.mkdir(dir)
+    old_mode = os.stat(outerdir).st_mode
+    os.chmod(outerdir, int('400', 8))
+    with pytest.raises(OSError):
+        engine = busbus.Engine({'busbus_dir': dir})
+    os.chmod(outerdir, old_mode)
+    os.rmdir(dir)
+    os.rmdir(outerdir)

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,21 @@
+from test_provider_gtfs import SampleGTFSProvider, provider
+
+import pytest
+
+
+@pytest.fixture(scope='module')
+def agency(provider):
+    return next(provider.agencies)
+
+
+def test_entity_repr(agency):
+    assert 'DTA' in repr(agency)
+
+
+def test_entity_failed_getattr(agency):
+    with pytest.raises(AttributeError):
+        agency.the_weather_in_london
+
+
+def test_entity_to_dict(agency):
+    assert agency.to_dict()['id'] == 'DTA'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,15 @@
+import busbus
+from busbus import util
+
+import pytest
+
+
+def test_util_clsname():
+    engine = busbus.Engine()
+    assert util.clsname(engine) == 'busbus.Engine'
+
+
+def test_util_entity_type_error():
+    engine = busbus.Engine()
+    with pytest.raises(TypeError):
+        busbus.util.entity_type(engine)


### PR DESCRIPTION
There are some cases here where I changed the actual code; most of those instances are changing `return NotImplemented` or the like to a docstring in abstract methods. Because it's impossible to run an abstract method as-defined, it's not possible to test code coverage; it's also not possible for the contents to matter at all, so why not document what it should do?

The other two cases:
* added the attribute not found as an argument to `AttributeError` in `busbus.entity.BaseEntity.__getattr__`
* `ProviderBase._new_entity` is no longer an abstract method (it does nothing if you don't override it)