### PR TITLE
Lawrence Transit provider + inexact stop time fix

### DIFF
--- a/busbus/provider/lawrenceks.py
+++ b/busbus/provider/lawrenceks.py
@@ -1,0 +1,10 @@
+from busbus.provider import ProviderBase
+from busbus.provider.gtfs import GTFSMixin
+
+
+class LawrenceTransitProvider(GTFSMixin, ProviderBase):
+    gtfs_url = ("http://lawrenceks.org/assets/gis/google-transit/"
+                "google_transit.zip")
+
+    def __init__(self, engine=None):
+        super(LawrenceTransitProvider, self).__init__(engine, self.gtfs_url)

--- a/tests/test_provider_lawrenceks.py
+++ b/tests/test_provider_lawrenceks.py
@@ -1,0 +1,19 @@
+import busbus
+from busbus.provider.lawrenceks import LawrenceTransitProvider
+
+import arrow
+import pytest
+
+
+@pytest.fixture(scope='module')
+def lawrenceks_provider():
+    return LawrenceTransitProvider()
+
+
+def test_43_to_eaton_hall(lawrenceks_provider):
+    stop = lawrenceks_provider.get(busbus.Stop, u'15TH_SPAHR_WB')
+    route = lawrenceks_provider.get(busbus.Route, u'RT_43')
+    assert len(list(lawrenceks_provider.arrivals.where(
+        stop=stop, route=route,
+        start_time=arrow.get('2015-03-10T14:00:00-05:00'),
+        end_time=arrow.get('2015-03-10T16:00:00-05:00')))) == 13


### PR DESCRIPTION
From the [GTFS reference](https://developers.google.com/transit/gtfs/reference#stop_times_fields):

> If this stop isn't a time point, use an empty string value for the arrival_time and departure_time fields. Stops without arrival times will be scheduled based on the nearest preceding timed stop.

We didn't do that yet! And Lawrence Transit's GTFS feed is full of these. Now we do that.

No live data (Lawrence Transit's live data is not an "open" service and won't be included in this repo).