### PR TITLE
Rewrite busbus.provider.gtfs to store data in a SQLite database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,15 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+sudo: false
+env:
+  - "APSW_VERSION=3.8.9-r1"
+before_install:
+  - "wget https://github.com/rogerbinns/apsw/releases/download/$APSW_VERSION/apsw-$APSW_VERSION.zip"
+  - "unzip apsw-$APSW_VERSION.zip"
 install:
-  - "pip install -U setuptools"
+  - "pip install -U pip setuptools"
+  - "cd apsw-$APSW_VERSION && python setup.py fetch --all build --enable-all-extensions install test && cd .. && rm -rf apsw-$APSW_VERSION apsw-$APSW_VERSION.zip"
   - "pip install -e . -e .[dev] -e .[web]"
 script: "coverage run --source busbus -m pytest --pep8"
 after_script:

--- a/busbus/__init__.py
+++ b/busbus/__init__.py
@@ -58,7 +58,7 @@ class Stop(BaseEntity):
 
     @property
     def children(self):
-        return self._provider.stops.where(lambda s: s.parent == self)
+        return self.provider.stops.where(lambda s: s.parent == self)
 
 
 class Route(BaseEntity):

--- a/busbus/__init__.py
+++ b/busbus/__init__.py
@@ -71,5 +71,8 @@ class Arrival(BaseEntity):
                  'short_name', 'bikes_ok')
     __repr_attrs__ = ('route', 'stop', 'time')
 
+    def __lt__(self, other):
+        return self.time < other.time
+
 
 ENTITIES = (Agency, Stop, Route, Arrival)

--- a/busbus/entity.py
+++ b/busbus/entity.py
@@ -18,7 +18,7 @@ class LazyEntityProperty(object):
         return self.f(*self.args, **self.kwargs)
 
 
-class BaseEntity(object):
+class BaseEntity(collections.Mapping):
     __repr_attrs__ = ('id',)
     __derived__ = False
 
@@ -54,14 +54,18 @@ class BaseEntity(object):
     def __getitem__(self, name):
         try:
             return getattr(self, name)
-        except AttributeError:
+        except (AttributeError, TypeError):
             raise KeyError(name)
 
-    def keys(self):
+    def __iter__(self):
         yield 'provider'
         for attr in self.__attrs__:
             if getattr(self, attr, None) is not None:
                 yield attr
+
+    def __len__(self):
+        return 1 + sum([1 for attr in self.__attrs__
+                        if getattr(self, attr, None) is not None])
 
 
 class BaseEntityJSONEncoder(json.JSONEncoder):

--- a/busbus/provider/gtfs.py
+++ b/busbus/provider/gtfs.py
@@ -459,8 +459,8 @@ class GTFSMixin(object):
                     right = min(filter(lambda k: k > seq, known_times))
                     start = known_times[left].get('d', known_times[left]['a'])
                     gap = known_times[right]['a'] - start
-                    count = len(filter(lambda k: left < k < right,
-                                       unknown_times)) + 1
+                    count = len(list(filter(lambda k: left < k < right,
+                                            unknown_times))) + 1
                     time = ((gap.total_seconds() * (i + 1) / count) +
                             start.total_seconds())
                     self.conn.execute(

--- a/busbus/provider/gtfs.py
+++ b/busbus/provider/gtfs.py
@@ -37,16 +37,17 @@ def parse_gtfs_time(timestr):
     This function returns a timedelta, which contains the number of seconds
     since noon represented by a time on a given day.
     """
-    split = [int(x) for x in timestr.split(':')[-3:]]
-    split = [0] * (3 - len(split)) + split
-    return datetime.timedelta(hours=split[0] - 12, minutes=split[1],
-                              seconds=split[2])
+    split = timestr.split(':')
+    seconds = int(split[-1])
+    minutes = int(split[-2]) if len(split) > 1 else 0
+    hours = int(split[-3]) if len(split) > 2 else 0
+    return (hours - 12) * 3600 + minutes * 60 + seconds
 
 
 def fix_type(value, typename):
     return {
         'date': lambda s: arrow.get(s, 'YYYYMMDD').date(),
-        'gtfstime': lambda s: parse_gtfs_time(s).total_seconds(),
+        'gtfstime': lambda s: parse_gtfs_time(s),
         'integer': int,
         'real': float,
         'timedelta': int,

--- a/busbus/provider/gtfs.py
+++ b/busbus/provider/gtfs.py
@@ -4,11 +4,9 @@ import busbus
 import busbus.entity
 from busbus.queryable import Queryable
 from busbus import util
-import busbus.util.csv as utilcsv
+from busbus.util.csv import CSVReader
 
 import arrow
-import codecs
-import collections
 import datetime
 import hashlib
 import heapq
@@ -423,8 +421,7 @@ class GTFSMixin(object):
                         continue
                     with z.open(filename) as f:
                         data = six.moves.map(lambda d: dict(itertools.chain(
-                            d, [(u'_feed_url', gtfs_url)])),
-                                             utilcsv.CSVReader(f))
+                            d, [(u'_feed_url', gtfs_url)])), CSVReader(f))
                         columns = {x[1]: x[2] for x in self.conn.execute(
                             'pragma table_info({0})'.format(table))}
                         stmt = ('INSERT INTO {0} ({1}) VALUES ({2})'

--- a/busbus/provider/gtfs.py
+++ b/busbus/provider/gtfs.py
@@ -209,7 +209,7 @@ class ArrivalIterator(util.Iterable):
         self.start = (arrow.now() if start is None
                       else arrow.get(start)).to(provider._timezone)
         self.end = (self.start.replace(hours=3) if end is None
-                    else arrow.get(start)).to(provider._timezone)
+                    else arrow.get(end)).to(provider._timezone)
         self.service_cache = {}
         self.freq_cache = {}
         self.it = None

--- a/busbus/provider/gtfs.py
+++ b/busbus/provider/gtfs.py
@@ -427,7 +427,8 @@ class GTFSMixin(object):
                         data = CSVReader(f)
                         columns = []
                         col_types = []
-                        for x in self.conn.execute('pragma table_info({0})'.format(table)):
+                        for x in self.conn.execute(
+                                'pragma table_info({0})'.format(table)):
                             if x[1] in data.header:
                                 columns.append(x[1])
                                 col_types.append(x[2])
@@ -438,6 +439,7 @@ class GTFSMixin(object):
                         stmt = ('INSERT INTO {0} ({1}) VALUES ({2})'
                                 .format(table, ', '.join(columns),
                                         ', '.join(('?',) * len(columns))))
+
                         def get(row, i):
                             if columns[i] == '_feed_url':
                                 return gtfs_url
@@ -445,7 +447,8 @@ class GTFSMixin(object):
                                 return fix_type(row[i], col_types[i])
                             else:
                                 return None
-                        row_gen = ([get(row, i) for i in range(len(columns))] for row in data)
+                        row_gen = ([get(row, i) for i in range(len(columns))]
+                                   for row in data)
                         self.conn.executemany(stmt, row_gen)
             self.conn.commit()
 

--- a/busbus/provider/gtfs.py
+++ b/busbus/provider/gtfs.py
@@ -279,8 +279,8 @@ class ArrivalIterator(util.Iterable):
                     yield arrival
 
     def _valid_date_filter(self, service_id):
-        serv = self._service(service_id)
         def valid_date(day):
+            serv = self._service(service_id)
             weekday = day.format('dddd').lower()
             day = day.date()  # convert from Arrow to datetime.date
             # schedule exceptions: 1 = added, 2 = removed
@@ -422,7 +422,9 @@ class GTFSMixin(object):
                     if filename not in z.namelist():
                         continue
                     with z.open(filename) as f:
-                        data = six.moves.map(lambda d: dict(itertools.chain(d, [(u'_feed_url', gtfs_url)])), utilcsv.CSVReader(f))
+                        data = six.moves.map(lambda d: dict(itertools.chain(
+                            d, [(u'_feed_url', gtfs_url)])),
+                                             utilcsv.CSVReader(f))
                         columns = {x[1]: x[2] for x in self.conn.execute(
                             'pragma table_info({0})'.format(table))}
                         stmt = ('INSERT INTO {0} ({1}) VALUES ({2})'

--- a/busbus/provider/gtfs.py
+++ b/busbus/provider/gtfs.py
@@ -61,9 +61,10 @@ for typename in ('gtfstime', 'timedelta'):
 class SQLEntityMixin(object):
 
     def __eq__(self, other):
-        if not ('id' in self and 'id' in other):
+        if not isinstance(other, SQLEntityMixin):
             return False
-        return self['id'] == other['id']
+        return (self.id == getattr(other, 'id', not self.id) and
+                self.provider == getattr(other, 'provider', not self.provider))
 
     @classmethod
     def _build_select(cls, columns, named_params=False):

--- a/busbus/provider/gtfs.py
+++ b/busbus/provider/gtfs.py
@@ -434,8 +434,9 @@ class GTFSMixin(object):
             self.conn.commit()
 
             # interpolate missing stop times
-            for row in self.conn.execute('''select trip_id from stop_times
-                                         where arrival_time is null'''):
+            for row in self.conn.execute(
+                    '''select trip_id from stop_times where arrival_time is
+                    null and _feed_url=?''', (self.gtfs_url,)):
                 trip_id = row['trip_id']
                 times = [dict(r) for r in self.conn.execute(
                     '''select arrival_time as a, departure_time as d,

--- a/busbus/provider/gtfs.py
+++ b/busbus/provider/gtfs.py
@@ -486,6 +486,10 @@ class GTFSMixin(object):
             busbus.Stop: GTFSStop,
             busbus.Route: GTFSRoute,
         }
+        try:
+            cls = util.entity_type(cls)
+        except TypeError:
+            return default
         if cls in typemap:
             return typemap[cls].from_id(self, id, default)
         else:

--- a/busbus/provider/gtfs.py
+++ b/busbus/provider/gtfs.py
@@ -389,10 +389,7 @@ class GTFSMixin(object):
     def __init__(self, engine, gtfs_url):
         super(GTFSMixin, self).__init__(engine)
 
-        db_path = self.engine.config.get(
-            'gtfs_db_path',
-            os.path.join(self.engine.config['busbus_dir'], 'gtfs.sqlite3'))
-        self.conn = apsw.Connection(db_path)
+        self.conn = apsw.Connection(self.engine.config['gtfs_db_path'])
         self.conn.setrowtrace(gtfs_row_tracer)
         cur = self.conn.cursor()
 

--- a/busbus/provider/gtfs.py
+++ b/busbus/provider/gtfs.py
@@ -221,7 +221,7 @@ class ArrivalIterator(util.Iterable):
             from trips_v as t join stop_times as st on
                 t.trip_id=st.trip_id and t._feed_url=st._feed_url
             where route_id=:route_id and stop_id=:stop_id and
-                t._feed_url=:_feed_url"""
+                t._feed_url=:_feed_url order by arrival_time asc"""
             iters = []
             for stop, route in itertools.product(self.stops, self.routes):
                 for stop_time in self.provider.conn.execute(st_query, {

--- a/busbus/provider/gtfs_2015020201.sql
+++ b/busbus/provider/gtfs_2015020201.sql
@@ -1,6 +1,8 @@
 -- this must be the same as SCHEMA_USER_VERSION in gtfs.py
 pragma user_version = 2015020201;
 
+-- TABLES ---------------------------------------------------------------------
+
 create table _feeds (
     url text,
     sha256sum text,
@@ -172,3 +174,10 @@ create table feed_info (
     feed_end_date date,
     feed_version text
 );
+
+-- VIEWS ----------------------------------------------------------------------
+
+create view trips_v as
+    select t.*, st.min_arrival_time from trips as t join
+        (select _feed_url, trip_id, min(arrival_time) as min_arrival_time from stop_times group by trip_id) as st
+        on t.trip_id=st.trip_id and t._feed_url=st._feed_url;

--- a/busbus/provider/gtfs_2015020201.sql
+++ b/busbus/provider/gtfs_2015020201.sql
@@ -80,6 +80,7 @@ create table stop_times (
     -- GTFS says arrival_time/departure_time are required but they're actually
     -- not; if missing they are to be interpolated
     arrival_time gtfstime,
+    _arrival_interpolate gtfstime,
     departure_time gtfstime,
     stop_id text not null,
     stop_sequence integer not null,
@@ -184,5 +185,6 @@ create table feed_info (
 
 create view trips_v as
     select t.*, st.min_arrival_time from trips as t join
-        (select _feed_url, trip_id, min(arrival_time) as min_arrival_time from stop_times group by trip_id) as st
+        (select _feed_url, trip_id, min(coalesce(arrival_time, _arrival_interpolate)) as min_arrival_time
+            from stop_times group by trip_id) as st
         on t.trip_id=st.trip_id and t._feed_url=st._feed_url;

--- a/busbus/provider/gtfs_2015020201.sql
+++ b/busbus/provider/gtfs_2015020201.sql
@@ -4,13 +4,14 @@ pragma user_version = 2015020201;
 -- TABLES ---------------------------------------------------------------------
 
 create table _feeds (
-    url text,
-    sha256sum text,
-    primary key (url)
+    id integer not null,
+    url text not null,
+    sha256sum text not null,
+    primary key (id)
 );
 
 create table agency (
-    _feed_url text not null,
+    _feed integer not null,
     agency_id text,
     agency_name text not null,
     agency_url text not null,
@@ -18,12 +19,12 @@ create table agency (
     agency_lang text,
     agency_phone text,
     agency_fare_url text,
-    primary key (_feed_url, agency_id),
-    foreign key (_feed_url) references _feeds (url)
+    primary key (_feed, agency_id),
+    foreign key (_feed) references _feeds (url)
 );
 
 create table stops (
-    _feed_url text not null,
+    _feed integer not null,
     stop_id text not null,
     stop_code text,
     stop_name text not null,
@@ -36,13 +37,13 @@ create table stops (
     parent_station text,
     stop_timezone text,
     wheelchair_boarding text,
-    primary key (_feed_url, stop_id),
-    foreign key (_feed_url) references _feeds (url),
-    foreign key (_feed_url, parent_station) references stops (_feed_url, stop_id)
+    primary key (_feed, stop_id),
+    foreign key (_feed) references _feeds (url),
+    foreign key (_feed, parent_station) references stops (_feed, stop_id)
 );
 
 create table routes (
-    _feed_url text not null,
+    _feed integer not null,
     route_id text not null,
     agency_id text,
     -- "At least one of route_short_name or route_long_name must be specified"
@@ -53,12 +54,12 @@ create table routes (
     route_url text,
     route_color text,
     route_text_color text,
-    primary key (_feed_url, route_id),
-    foreign key (_feed_url, agency_id) references agencies (_feed_url, agency_id)
+    primary key (_feed, route_id),
+    foreign key (_feed, agency_id) references agencies (_feed, agency_id)
 );
 
 create table trips (
-    _feed_url text not null,
+    _feed integer not null,
     route_id text not null,
     service_id text not null,
     trip_id text not null,
@@ -69,13 +70,13 @@ create table trips (
     shape_id text,
     wheelchair_accessible integer,
     bikes_allowed integer,
-    primary key (_feed_url, trip_id),
-    foreign key (_feed_url, route_id) references routes (_feed_url, route_id),
-    foreign key (_feed_url, service_id) references calendar (_feed_url, service_id)
+    primary key (_feed, trip_id),
+    foreign key (_feed, route_id) references routes (_feed, route_id),
+    foreign key (_feed, service_id) references calendar (_feed, service_id)
 );
 
 create table stop_times (
-    _feed_url text not null,
+    _feed integer not null,
     trip_id text not null,
     -- GTFS says arrival_time/departure_time are required but they're actually
     -- not; if missing they are to be interpolated
@@ -89,13 +90,13 @@ create table stop_times (
     drop_off_type integer,
     shape_dist_traveled real,
     timepoint integer,
-    primary key (_feed_url, trip_id, stop_sequence),
-    foreign key (_feed_url, trip_id) references trips (_feed_url, trip_id),
-    foreign key (_feed_url, stop_id) references stops (_feed_url, stop_id)
+    primary key (_feed, trip_id, stop_sequence),
+    foreign key (_feed, trip_id) references trips (_feed, trip_id),
+    foreign key (_feed, stop_id) references stops (_feed, stop_id)
 );
 
 create table calendar (
-    _feed_url text not null,
+    _feed integer not null,
     service_id text not null,
     monday integer not null,
     tuesday integer not null,
@@ -106,52 +107,52 @@ create table calendar (
     sunday integer not null,
     start_date date not null,
     end_date date not null,
-    primary key (_feed_url, service_id)
+    primary key (_feed, service_id)
 );
 
 create table calendar_dates (
-    _feed_url text not null,
+    _feed integer not null,
     service_id text not null,
     date date not null,
     exception_type integer not null,
-    foreign key (_feed_url, service_id) references calendar (_feed_url, service_id)
+    foreign key (_feed, service_id) references calendar (_feed, service_id)
 );
 
 /*
 create table fare_attributes (
-    _feed_url text not null,
+    _feed integer not null,
     fare_id text not null,
     price text not null, -- text is deliberate; floating point currency is a nightmare
     currency_type text not null,
     payment_method integer not null,
     transfers integer not null,
     transfer_duration timedelta,
-    primary key (_feed_url, fare_id)
+    primary key (_feed, fare_id)
 );
 
 create table fare_rules (
-    _feed_url text not null,
+    _feed integer not null,
     fare_id text not null,
     route_id text,
     origin_id text,
     destination_id text,
     contains_id text,
-    foreign key (_feed_url, fare_id) references fare_attributes (_feed_url, fare_id)
+    foreign key (_feed, fare_id) references fare_attributes (_feed, fare_id)
 );
 
 create table shapes (
-    _feed_url text not null,
+    _feed integer not null,
     shape_id text not null,
     shape_pt_lat real not null,
     shape_pt_lon real not null,
     shape_pt_sequence integer not null,
     shape_dist_traveled real,
-    primary key (_feed_url, shape_id, shape_pt_sequence)
+    primary key (_feed, shape_id, shape_pt_sequence)
 );
 */
 
 create table frequencies (
-    _feed_url text not null,
+    _feed integer not null,
     trip_id text not null,
     start_time gtfstime not null,
     end_time gtfstime not null,
@@ -161,17 +162,17 @@ create table frequencies (
 
 /*
 create table transfers (
-    _feed_url text not null,
+    _feed integer not null,
     from_stop_id text not null,
     to_stop_id text not null,
     transfer_type integer not null,
     min_transfer_time timedelta,
-    foreign key (_feed_url, from_stop_id) references stops (_feed_url, stop_id),
-    foreign key (_feed_url, to_stop_id) references stops (_feed_url, stop_id)
+    foreign key (_feed, from_stop_id) references stops (_feed, stop_id),
+    foreign key (_feed, to_stop_id) references stops (_feed, stop_id)
 );
 
 create table feed_info (
-    _feed_url text not null,
+    _feed integer not null,
     feed_publisher_name text not null,
     feed_publisher_url text not null,
     feed_lang text not null,
@@ -185,6 +186,6 @@ create table feed_info (
 
 create view trips_v as
     select t.*, st.min_arrival_time from trips as t join
-        (select _feed_url, trip_id, min(coalesce(arrival_time, _arrival_interpolate)) as min_arrival_time
+        (select _feed, trip_id, min(coalesce(arrival_time, _arrival_interpolate)) as min_arrival_time
             from stop_times group by trip_id) as st
-        on t.trip_id=st.trip_id and t._feed_url=st._feed_url;
+        on t.trip_id=st.trip_id and t._feed=st._feed;

--- a/busbus/provider/gtfs_2015020201.sql
+++ b/busbus/provider/gtfs_2015020201.sql
@@ -1,0 +1,174 @@
+-- this must be the same as SCHEMA_USER_VERSION in gtfs.py
+pragma user_version = 2015020201;
+
+create table _feeds (
+    url text,
+    sha256sum text,
+    primary key (url)
+);
+
+create table agency (
+    _feed_url text not null,
+    agency_id text,
+    agency_name text not null,
+    agency_url text not null,
+    agency_timezone text not null,
+    agency_lang text,
+    agency_phone text,
+    agency_fare_url text,
+    primary key (_feed_url, agency_id),
+    foreign key (_feed_url) references _feeds (url)
+);
+
+create table stops (
+    _feed_url text not null,
+    stop_id text not null,
+    stop_code text,
+    stop_name text not null,
+    stop_desc text,
+    stop_lat real not null,
+    stop_lon real not null,
+    zone_id text,
+    stop_url text,
+    location_type integer,
+    parent_station text,
+    stop_timezone text,
+    wheelchair_boarding text,
+    primary key (_feed_url, stop_id),
+    foreign key (_feed_url) references _feeds (url),
+    foreign key (_feed_url, parent_station) references stops (_feed_url, stop_id)
+);
+
+create table routes (
+    _feed_url text not null,
+    route_id text not null,
+    agency_id text,
+    -- If the route does not have a short name, please specify a
+    -- route_long_name and use an empty string as the value for this field.
+    route_short_name text,
+    route_long_name text not null,
+    route_desc text,
+    route_type integer not null,
+    route_url text,
+    route_color text,
+    route_text_color text,
+    primary key (_feed_url, route_id),
+    foreign key (_feed_url, agency_id) references agencies (_feed_url, agency_id)
+);
+
+create table trips (
+    _feed_url text not null,
+    route_id text not null,
+    service_id text not null,
+    trip_id text not null,
+    trip_headsign text,
+    trip_short_name text,
+    direction_id integer,
+    block_id text,
+    shape_id text,
+    wheelchair_accessible integer,
+    bikes_allowed integer,
+    primary key (_feed_url, trip_id),
+    foreign key (_feed_url, route_id) references routes (_feed_url, route_id),
+    foreign key (_feed_url, service_id) references calendar (_feed_url, service_id)
+);
+
+create table stop_times (
+    _feed_url text not null,
+    trip_id text not null,
+    -- GTFS says arrival_time/departure_time are required but they're actually
+    -- not; if missing they are to be interpolated
+    arrival_time gtfstime,
+    departure_time gtfstime,
+    stop_id text not null,
+    stop_sequence integer not null,
+    stop_headsign text,
+    pickup_type integer,
+    drop_off_type integer,
+    shape_dist_traveled real,
+    timepoint integer,
+    foreign key (_feed_url, trip_id) references trips (_feed_url, trip_id),
+    foreign key (_feed_url, stop_id) references stops (_feed_url, stop_id)
+);
+
+create table calendar (
+    _feed_url text not null,
+    service_id text not null,
+    monday integer not null,
+    tuesday integer not null,
+    wednesday integer not null,
+    thursday integer not null,
+    friday integer not null,
+    saturday integer not null,
+    sunday integer not null,
+    start_date date not null,
+    end_date date not null,
+    primary key (_feed_url, service_id)
+);
+
+create table calendar_dates (
+    _feed_url text not null,
+    service_id text not null,
+    date date not null,
+    exception_type integer not null,
+    foreign key (_feed_url, service_id) references calendar (_feed_url, service_id)
+);
+
+create table fare_attributes (
+    _feed_url text not null,
+    fare_id text not null,
+    price text not null, -- text is deliberate; floating point currency is a nightmare
+    currency_type text not null,
+    payment_method integer not null,
+    transfers integer not null,
+    transfer_duration timedelta,
+    primary key (_feed_url, fare_id)
+);
+
+create table fare_rules (
+    _feed_url text not null,
+    fare_id text not null,
+    route_id text,
+    origin_id text,
+    destination_id text,
+    contains_id text,
+    foreign key (_feed_url, fare_id) references fare_attributes (_feed_url, fare_id)
+);
+
+create table shapes (
+    _feed_url text not null,
+    shape_id text not null,
+    shape_pt_lat real not null,
+    shape_pt_lon real not null,
+    shape_pt_sequence integer not null,
+    shape_dist_traveled real
+);
+
+create table frequencies (
+    _feed_url text not null,
+    trip_id text not null,
+    start_time gtfstime not null,
+    end_time gtfstime not null,
+    headway_secs timedelta not null,
+    exact_times integer
+);
+
+create table transfers (
+    _feed_url text not null,
+    from_stop_id text not null,
+    to_stop_id text not null,
+    transfer_type integer not null,
+    min_transfer_time timedelta,
+    foreign key (_feed_url, from_stop_id) references stops (_feed_url, stop_id),
+    foreign key (_feed_url, to_stop_id) references stops (_feed_url, stop_id)
+);
+
+create table feed_info (
+    _feed_url text not null,
+    feed_publisher_name text not null,
+    feed_publisher_url text not null,
+    feed_lang text not null,
+    feed_start_date date,
+    feed_end_date date,
+    feed_version text
+);

--- a/busbus/provider/gtfs_2015020201.sql
+++ b/busbus/provider/gtfs_2015020201.sql
@@ -89,6 +89,7 @@ create table stop_times (
     drop_off_type integer,
     shape_dist_traveled real,
     timepoint integer,
+    primary key (_feed_url, trip_id, stop_sequence),
     foreign key (_feed_url, trip_id) references trips (_feed_url, trip_id),
     foreign key (_feed_url, stop_id) references stops (_feed_url, stop_id)
 );
@@ -116,6 +117,7 @@ create table calendar_dates (
     foreign key (_feed_url, service_id) references calendar (_feed_url, service_id)
 );
 
+/*
 create table fare_attributes (
     _feed_url text not null,
     fare_id text not null,
@@ -143,8 +145,10 @@ create table shapes (
     shape_pt_lat real not null,
     shape_pt_lon real not null,
     shape_pt_sequence integer not null,
-    shape_dist_traveled real
+    shape_dist_traveled real,
+    primary key (_feed_url, shape_id, shape_pt_sequence)
 );
+*/
 
 create table frequencies (
     _feed_url text not null,
@@ -155,6 +159,7 @@ create table frequencies (
     exact_times integer
 );
 
+/*
 create table transfers (
     _feed_url text not null,
     from_stop_id text not null,
@@ -174,6 +179,7 @@ create table feed_info (
     feed_end_date date,
     feed_version text
 );
+*/
 
 -- VIEWS ----------------------------------------------------------------------
 

--- a/busbus/provider/gtfs_2015020201.sql
+++ b/busbus/provider/gtfs_2015020201.sql
@@ -45,10 +45,9 @@ create table routes (
     _feed_url text not null,
     route_id text not null,
     agency_id text,
-    -- If the route does not have a short name, please specify a
-    -- route_long_name and use an empty string as the value for this field.
+    -- "At least one of route_short_name or route_long_name must be specified"
     route_short_name text,
-    route_long_name text not null,
+    route_long_name text,
     route_desc text,
     route_type integer not null,
     route_url text,

--- a/busbus/provider/mbta.py
+++ b/busbus/provider/mbta.py
@@ -32,6 +32,6 @@ class MBTAProvider(GTFSMixin, ProviderBase):
 
     gtfs_url = "http://www.mbta.com/uploadedfiles/MBTA_GTFS.zip"
 
-    def __init__(self, engine, mbta_api_key):
+    def __init__(self, mbta_api_key, engine=None):
         super(MBTAProvider, self).__init__(engine, self.gtfs_url)
         self.mbta_api_key = mbta_api_key

--- a/busbus/util/__init__.py
+++ b/busbus/util/__init__.py
@@ -38,6 +38,8 @@ class Config(collections.defaultdict):
                 return os.path.join(os.getcwd(), '.busbus')
         elif key == 'url_cache_dir':
             return os.path.join(self['busbus_dir'], 'cache')
+        elif key == 'gtfs_db_path':
+            return os.path.join(self['busbus_dir'], 'gtfs.sqlite3')
         else:
             raise KeyError(key)
 

--- a/busbus/util/__init__.py
+++ b/busbus/util/__init__.py
@@ -62,7 +62,7 @@ def clsname(obj):
 
 
 def freezehash(obj):
-    if isinstance(obj, dict):
+    if isinstance(obj, (dict, collections.Mapping)):
         return hash(frozenset((k, freezehash(v)) for k, v in obj.items()))
     elif isinstance(obj, (tuple, list, set)):
         return hash(frozenset(freezehash(x) for x in obj))

--- a/busbus/util/__init__.py
+++ b/busbus/util/__init__.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 import collections
+import math
 import os
 import six
 
@@ -67,3 +68,14 @@ def freezehash(obj):
         return hash(frozenset(freezehash(x) for x in obj))
     else:
         return hash(obj)
+
+
+def dist(lat1, lon1, lat2, lon2):
+    """
+    Returns the distance between two latitude/longitude pairs in
+    meters.
+    """
+    lat1, lon1, lat2, lon2 = map(math.radians, (lat1, lon1, lat2, lon2))
+    return math.acos(math.sin(lat1) * math.sin(lat2) +
+                     math.cos(lat1) * math.cos(lat2) *
+                     math.cos(abs(lon2 - lon1))) * 6371000

--- a/busbus/util/csv.py
+++ b/busbus/util/csv.py
@@ -27,5 +27,7 @@ class CSVReader(util.Iterable):
     def __next__(self):
         row = next(self.reader)
         if six.PY2:
-            row = (x.decode('utf-8') for x in row)
-        return six.moves.zip(self.header, row)
+            func = lambda x: x.decode('utf-8') if x else None
+        else:
+            func = lambda x: x if x else None
+        return [func(x) for x in row]

--- a/busbus/web.py
+++ b/busbus/web.py
@@ -1,11 +1,11 @@
 import busbus
 from busbus.entity import BaseEntityJSONEncoder
 from busbus.provider import ProviderBase
+from busbus.util import dist
 
 import cherrypy
 import collections
 import itertools
-import math
 import types
 
 
@@ -137,17 +137,6 @@ class Engine(busbus.Engine):
         }
 
     def stops_find(self, **kwargs):
-        def dist(lat1, lon1, lat2, lon2):
-            """
-            Returns the distance between two latitude/longitude pairs in
-            meters.
-            """
-            lat1, lon1, lat2, lon2 = map(math.radians,
-                                         (lat1, lon1, lat2, lon2))
-            return math.acos(math.sin(lat1) * math.sin(lat2) +
-                             math.cos(lat1) * math.cos(lat2) *
-                             math.cos(abs(lon2 - lon1))) * 6371000
-
         expected = ('latitude', 'longitude', 'distance')
         if all(x in kwargs for x in expected):
             for x in expected:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ pytest-pep8
 coverage
 python-coveralls
 wsgi_intercept
+mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ lockfile
 phonenumbers
 # date/time library -- ASL license
 arrow
+# another python sqlite wrapper -- zlib license (or any OSI-approved license)
+apsw

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[pep8]
+ignore = E731
+
+[pytest]
+pep8ignore = E731

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,15 @@ class SampleGTFSProvider(GTFSMixin, ProviderBase):
 
 
 @pytest.fixture(scope='session')
-def engine():
-    return busbus.Engine()
+def engine_config():
+    return {
+        'gtfs_db_path': ':memory:',
+    }
+
+
+@pytest.fixture(scope='session')
+def engine(engine_config):
+    return busbus.Engine(engine_config)
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,11 @@ from busbus.provider import ProviderBase
 from busbus.provider.gtfs import GTFSMixin
 
 import arrow
+try:
+    # prefer the stdlib version of mock (>= 3.3)
+    import unittest.mock as mock
+except ImportError:
+    import mock
 import pytest
 
 
@@ -16,11 +21,12 @@ class SampleGTFSProvider(GTFSMixin, ProviderBase):
                     'sample-feed.zip')
         super(SampleGTFSProvider, self).__init__(engine, gtfs_url)
 
-    def _build_arrivals(self, kw):
-        # Set a default start_time that fits within the sample feed's dates
-        if 'start_time' not in kw:
-            kw['start_time'] = arrow.get('2007-06-03T06:45:00-07:00')
-        return super(SampleGTFSProvider, self)._build_arrivals(kw)
+    @property
+    def arrivals(self):
+        # Set a current time that fits within the sample feed's dates
+        with mock.patch('arrow.now') as mock_now:
+            mock_now.return_value = arrow.get('2007-06-03T06:45:00-07:00')
+            return super(SampleGTFSProvider, self).arrivals
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_provider_gtfs.py
+++ b/tests/test_provider_gtfs.py
@@ -52,7 +52,7 @@ entity_len_params = [
     ('stops', 9),
     ('routes', 5),
     # keep in mind this is from 2007-06-03T06:45:00-07:00 to 09:45:00
-    ('arrivals', 141),
+    ('arrivals', 139),
 ]
 
 
@@ -106,15 +106,16 @@ def test_routes_agency(provider):
     # STBA: 6 arrivals (every half hour)
     # CITY1: 2 arrivals from 06:45-07:59 (every half hour)
     #       10 arrivals from 08:00-09:45 (every 10 minutes)
-    # CITY2: same, plus another arrival from the 06:30 trip
+    # CITY2: 3 arrivals from 06:45-07:59 (trip start time)
+    #        9 arrivals from 08:00-09:45 (trip start time)
     # Sunday
-    ('2007-06-03T06:45:00-07:00', u'STAGECOACH', 31),
+    ('2007-06-03T06:45:00-07:00', u'STAGECOACH', 30),
     ('2007-06-03T06:45:00-07:00', u'AMV', 1),
     # Monday (FULLW exception)
     ('2007-06-04T06:45:00-07:00', u'STAGECOACH', 0),
     ('2007-06-04T06:45:00-07:00', u'AMV', 0),
     # Tuesday
-    ('2007-06-05T06:45:00-07:00', u'STAGECOACH', 31),
+    ('2007-06-05T06:45:00-07:00', u'STAGECOACH', 30),
     ('2007-06-05T06:45:00-07:00', u'AMV', 0)
 ])
 def test_valid_arrivals(provider, time, stop_id, count):

--- a/tests/test_provider_gtfs.py
+++ b/tests/test_provider_gtfs.py
@@ -18,8 +18,10 @@ def test_engine_has_one_provider(engine, provider):
     assert len(engine._providers) == 1
 
 
-def test_provider_get_default(provider):
-    assert provider.get(None, u'The weather in london', 'asdfjkl') == 'asdfjkl'
+@pytest.mark.parametrize('entity', (None, busbus.Stop, busbus.Arrival))
+def test_provider_get_default(provider, entity):
+    assert provider.get(entity, u'The weather in london',
+                        'asdfjkl') == 'asdfjkl'
 
 
 def test_sql_entity_mixin_build_select():

--- a/tests/test_provider_gtfs.py
+++ b/tests/test_provider_gtfs.py
@@ -109,6 +109,13 @@ def test_stops_no_children(provider):
         assert len(list(stop.children)) == 0
 
 
+def test_stops_no_children_base(provider):
+    stop = next(provider.stops)
+    stop = busbus.Stop(**dict(stop))
+    print(type(stop))
+    assert len(list(stop.children)) == 0
+
+
 def test_agencies_unicode(provider):
     """
     Our CSV parser should be reading everything in as Unicode.

--- a/tests/test_provider_gtfs.py
+++ b/tests/test_provider_gtfs.py
@@ -38,13 +38,18 @@ def test_sql_entity_mixin_build_select():
 
 
 def test_sql_entity_eq(provider):
+    class FakeEntity(SQLEntityMixin):
+        pass
+
     a1 = provider.get(busbus.Agency, u'DTA')
     assert a1 == a1
     assert a1 is a1
+    assert a1 != 'the weather in london'
+    assert a1 != FakeEntity()
     a2 = provider.get(busbus.Agency, u'DTA')
     assert a1 == a2
     assert a2 == a1
-    assert not (a1 is a2)
+    assert a1 is not a2
 
 
 entity_len_params = [

--- a/tests/test_provider_gtfs.py
+++ b/tests/test_provider_gtfs.py
@@ -3,10 +3,12 @@ from .conftest import SampleGTFSProvider
 import busbus
 from busbus.provider import ProviderBase
 from busbus.provider.gtfs import SQLEntityMixin
+from busbus.util import Config
 
 import arrow
 from collections import OrderedDict
 import datetime
+import mock
 import pytest
 import six
 
@@ -34,6 +36,18 @@ def test_provider_without_engine():
             raise NotImplementedError
 
     TestProvider(None)
+
+
+def test_default_gtfs_db_path():
+    c = Config({'busbus_dir': '/tmp/busbus'})
+    assert c['gtfs_db_path'] == '/tmp/busbus/gtfs.sqlite3'
+
+
+def test_already_imported(provider):
+    e = busbus.Engine({'gtfs_db_path': provider.conn})
+    p = SampleGTFSProvider(e)
+    assert provider.feed_id == p.feed_id
+    assert len(list(provider.agencies)) == 1
 
 
 def test_engine_has_one_provider(engine, provider):

--- a/tests/test_provider_gtfs.py
+++ b/tests/test_provider_gtfs.py
@@ -1,6 +1,7 @@
 from .conftest import SampleGTFSProvider
 
 import busbus
+from busbus.provider import ProviderBase
 from busbus.provider.gtfs import SQLEntityMixin
 
 import arrow
@@ -11,7 +12,28 @@ import six
 
 
 def test_provider_without_engine():
-    SampleGTFSProvider()
+    class TestProvider(ProviderBase):
+
+        def get(self, *args, **kwargs):
+            raise NotImplementedError
+
+        @property
+        def agencies(self):
+            raise NotImplementedError
+
+        @property
+        def routes(self):
+            raise NotImplementedError
+
+        @property
+        def stops(self):
+            raise NotImplementedError
+
+        @property
+        def arrivals(self):
+            raise NotImplementedError
+
+    TestProvider(None)
 
 
 def test_engine_has_one_provider(engine, provider):

--- a/tests/test_provider_lawrenceks.py
+++ b/tests/test_provider_lawrenceks.py
@@ -15,10 +15,14 @@ def test_agency_phone_e164(lawrenceks_provider):
     assert agency.phone_e164 == '+17858644644'
 
 
-def test_43_to_eaton_hall(lawrenceks_provider):
-    stop = lawrenceks_provider.get(busbus.Stop, u'15TH_SPAHR_WB')
+@pytest.mark.parametrize('stop_id,count', [
+    (u'15TH_SPAHR_WB', 13),
+    (u'SNOW_HALL_WB', 14),
+])
+def test_43_to_eaton_hall(lawrenceks_provider, stop_id, count):
+    stop = lawrenceks_provider.get(busbus.Stop, stop_id)
     route = lawrenceks_provider.get(busbus.Route, u'RT_43')
     assert len(list(lawrenceks_provider.arrivals.where(
         stop=stop, route=route,
         start_time=arrow.get('2015-03-10T14:00:00-05:00'),
-        end_time=arrow.get('2015-03-10T16:00:00-05:00')))) == 13
+        end_time=arrow.get('2015-03-10T16:00:00-05:00')))) == count

--- a/tests/test_provider_lawrenceks.py
+++ b/tests/test_provider_lawrenceks.py
@@ -10,6 +10,11 @@ def lawrenceks_provider(engine):
     return LawrenceTransitProvider(engine)
 
 
+def test_agency_phone_e164(lawrenceks_provider):
+    agency = next(lawrenceks_provider.agencies)
+    assert agency.phone_e164 == '+17858644644'
+
+
 def test_43_to_eaton_hall(lawrenceks_provider):
     stop = lawrenceks_provider.get(busbus.Stop, u'15TH_SPAHR_WB')
     route = lawrenceks_provider.get(busbus.Route, u'RT_43')

--- a/tests/test_provider_lawrenceks.py
+++ b/tests/test_provider_lawrenceks.py
@@ -6,8 +6,8 @@ import pytest
 
 
 @pytest.fixture(scope='module')
-def lawrenceks_provider():
-    return LawrenceTransitProvider()
+def lawrenceks_provider(engine):
+    return LawrenceTransitProvider(engine)
 
 
 def test_43_to_eaton_hall(lawrenceks_provider):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -84,6 +84,10 @@ def test_unexpand_none(url_prefix):
     assert set(data['routes'][0]['agency'].keys()) == set(['id'])
 
 
+def test_unexpand_dict():
+    assert busbus.web.unexpand({1: 2}, ()) == {1: 2}
+
+
 def test_unexpand_agencies(url_prefix):
     data, resp = get(url_prefix + 'routes?_expand=agencies')
     assert 'timezone' in data['routes'][0]['agency']

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -10,8 +10,8 @@ from wsgi_intercept import requests_intercept, add_wsgi_intercept
 
 
 @pytest.fixture(scope='module')
-def url_prefix(request):
-    engine = busbus.web.Engine()
+def url_prefix(request, engine_config):
+    engine = busbus.web.Engine(engine_config)
     SampleGTFSProvider(engine)
 
     # https://cherrypy.readthedocs.org/en/latest/deploy.html


### PR DESCRIPTION
This pull request consists of a major rewrite of `busbus.provider.gtfs`, which is likely to be a core part of any data provider, to import GTFS data into an SQLite database and reference that when making queries, as opposed to importing and processing GTFS data into Python data types and holding them in memory.

This is actually an important rewrite; I don't just write +698/-442 commits for no reason. (ok maybe i do)

First, this (optionally!) drastically reduces the memory requirements for busbus. By default, instead of storing everything there possibly is to know about a transit agency in memory, we write it out to disk in a relatively quick-to-access format. (One can choose to still store it in memory anyway by passing `{"gtfs_db_path": ":memory:"}` as the config object to `busbus.Engine` — we do this in test cases to prevent the on-disk database from affecting test results.)

Second, this is a lot higher-quality code. Prior to this commit, attempting to instantiate `busbus.provider.mbta.MBTAProvider` resulted in an infinite loop somewhere that ate all your memory until the kernel oomkilled the python process. Now it actually loads (it currently takes almost 5 minutes on my home desktop, but we can look into that).

Third, arrivals are now generated in such a way that they can be sorted. (This would only be possible if it were extremely easy to order GTFS rows by arrival time, which, hey, that's exactly a use case for SQL.) This is rather expensive if you're not limiting arrivals to a certain stop or route; I'll look into this soon.

I'm going to do some profiling shortly to quantify the differences between current master and this branch in terms of initialization time, query time, and memory usage.