### PR TITLE
Fix travis-ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
 sudo: false
 env:
-  - "APSW_VERSION=3.8.8.2-r1"
+  - "APSW_VERSION=3.8.9-r1"
 before_install:
   - "gpg --keyserver hkp://keys.gnupg.net --recv-keys 02DA39A85354DD3D7343EFC198E39F1E0DFBD904"
   - "wget https://github.com/rogerbinns/apsw/releases/download/$APSW_VERSION/apsw-$APSW_VERSION.zip https://github.com/rogerbinns/apsw/releases/download/$APSW_VERSION/apsw-$APSW_VERSION-sigs.zip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ sudo: false
 env:
   - "APSW_VERSION=3.8.9-r1"
 before_install:
-  - "wget https://github.com/rogerbinns/apsw/releases/download/$APSW_VERSION/apsw-$APSW_VERSION.zip"
+  - "gpg --keyserver hkp://keys.gnupg.net --recv-keys 02DA39A85354DD3D7343EFC198E39F1E0DFBD904"
+  - "wget https://github.com/rogerbinns/apsw/releases/download/$APSW_VERSION/apsw-$APSW_VERSION.zip https://github.com/rogerbinns/apsw/releases/download/$APSW_VERSION/apsw-$APSW_VERSION-sigs.zip"
+  - "unzip -d apsw-sigs apsw-$APSW_VERSION-sigs.zip"
+  - "gpg --verify apsw-sigs/apsw-$APSW_VERSION.zip.asc"
   - "unzip apsw-$APSW_VERSION.zip"
 install:
   - "pip install -U pip setuptools"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
 sudo: false
 env:
-  - "APSW_VERSION=3.8.9-r1"
+  - "APSW_VERSION=3.8.8.2-r1"
 before_install:
   - "gpg --keyserver hkp://keys.gnupg.net --recv-keys 02DA39A85354DD3D7343EFC198E39F1E0DFBD904"
   - "wget https://github.com/rogerbinns/apsw/releases/download/$APSW_VERSION/apsw-$APSW_VERSION.zip https://github.com/rogerbinns/apsw/releases/download/$APSW_VERSION/apsw-$APSW_VERSION-sigs.zip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - "unzip apsw-$APSW_VERSION.zip"
 install:
   - "pip install -U pip setuptools"
-  - "cd apsw-$APSW_VERSION && python setup.py fetch --all build --enable-all-extensions install test && cd .. && rm -rf apsw-$APSW_VERSION apsw-$APSW_VERSION.zip"
+  - "cd apsw-$APSW_VERSION && python setup.py fetch --all --version=$(echo $APSW_VERSION | cut -d - -f 1) build --enable-all-extensions install test && cd .. && rm -rf apsw-$APSW_VERSION apsw-$APSW_VERSION.zip"
   - "pip install -e . -e .[dev] -e .[web]"
 script: "coverage run --source busbus -m pytest --pep8"
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ env:
 before_install:
   - "gpg --keyserver hkp://keys.gnupg.net --recv-keys 02DA39A85354DD3D7343EFC198E39F1E0DFBD904"
   - "wget https://github.com/rogerbinns/apsw/releases/download/$APSW_VERSION/apsw-$APSW_VERSION.zip https://github.com/rogerbinns/apsw/releases/download/$APSW_VERSION/apsw-$APSW_VERSION-sigs.zip"
-  - "unzip -d apsw-sigs apsw-$APSW_VERSION-sigs.zip"
-  - "gpg --verify apsw-sigs/apsw-$APSW_VERSION.zip.asc"
+  - "unzip -d apsw-sigs apsw-$APSW_VERSION-sigs.zip && mv apsw-sigs/apsw-$APSW_VERSION.zip.asc ./ && gpg --verify apsw-$APSW_VERSION.zip.asc"
   - "unzip apsw-$APSW_VERSION.zip"
 install:
   - "pip install -U pip setuptools"


### PR DESCRIPTION
SQLite released a new upstream release today, 3.8.10, which apparently breaks the APSW installation process in our `.travis.yml` in two ways:

- APSW 3.8.9-r1 has a strange artifact at the end of its `checksums` file where, if hit, causes an exception. Because 3.8.10 isn't in the `checksums` file it hits this artifact.
- APSW's `setup.py fetch` will, by default, grab the latest version of SQLite. Because the checksum isn't present in any currently-released version of APSW, it will always abort unless we tell it not to.

Additionally this commit adds GPG signature verification of the APSW zip download.